### PR TITLE
added new .sign method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 Gemfile.lock
 InstalledFiles
 _yardoc
+.idea/
 coverage
 doc/
 lib/bundler/man

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Coinpayments.configure do |config|
   config.merchant_id     = ''
   config.public_api_key  = ''
   config.private_api_key = ''
+  config.secret_phrase   = ''
 end
 ```
 
@@ -65,6 +66,13 @@ For example, to quickly access current BTC/USD exchange rate, use:
 ```
 transaction = Coinpayments.create_transaction(10, 'USD', 'BTC')
 @address = transaction.address
+```
+- You can recieve IPN callbacks after payments on API-generated addresses.
+Coinpayments server generates signature based on your secret phrase and row 
+body of POST request to your custom API. You can easily compare signatures
+to verify callback using 
+```
+Coinpayments.sign('IPN POST request row body')
 ```
 
 ## Contributing

--- a/lib/coinpayments.rb
+++ b/lib/coinpayments.rb
@@ -70,4 +70,8 @@ module Coinpayments
       api_call(args)
     end
 
+    def self.sign(callback_body)
+      OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha512'),
+                              configuration.secret_phrase,callback_body)
+    end
 end

--- a/lib/coinpayments/configuration.rb
+++ b/lib/coinpayments/configuration.rb
@@ -1,6 +1,6 @@
 module Coinpayments
   class Configuration
-    attr_accessor :version, :base_uri, :merchant_id, :public_api_key, :private_api_key
+    attr_accessor :version, :base_uri, :merchant_id, :public_api_key, :private_api_key, :secret_phrase
 
     def initialize
       @version = 1
@@ -8,6 +8,7 @@ module Coinpayments
       @merchant_id = ''
       @public_api_key = ''
       @private_api_key = ''
+      @secret_phrase = ''
     end
   end
 end

--- a/lib/generators/coinpayments/templates/coinpayments_initializer.rb
+++ b/lib/generators/coinpayments/templates/coinpayments_initializer.rb
@@ -2,4 +2,5 @@ Coinpayments.configure do |config|
   config.merchant_id     = ''
   config.public_api_key  = ''
   config.private_api_key = ''
+  config.secret_phrase   = ''
 end

--- a/test/coinpayments_test.rb
+++ b/test/coinpayments_test.rb
@@ -65,4 +65,11 @@ class CoinpaymentsTest < Minitest::Test
       assert r.respond_to?(:status_text)
     end
   end
+
+  def test_sign
+    VCR.use_cassette('sign') do
+      r = Coinpayments.sign('Secret Phrase')
+      assert r.size == 128
+    end
+  end
 end


### PR DESCRIPTION
This method allows you to make signature for comparison with Coinpayments API signature located in HTTP header 'Hmac'